### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This is a test file for Core 1.
 
-Please copy the file into your androidTest directory. You will need to edit the package name, as well as add `androidTestImplementation 'androidx.test:rules:1.4.0-beta02'` to your Gradle file (app level). 
+Copy the MainActivityTest.kt file into your androidTest directory. <AndoridStuiodProjects>/<projectname>/app/src/test/java/<package sub folders>/MainActivityTest.kt
+Edit Pakage name: Edit MainActivityTest.kt line 1 'package au.edu.swin.sdmd.core1sample' to match your environment. See your MainActivity.kt package name. 
+Add test module library to dependency list: Insert `  androidTestImplementation 'androidx.test:rules:1.4.0'  ` to the dependencies section of your Gradle Module build file. build.gradle (Module: <appname>.app). 
 
-To run the tests, click on the arrows next to `class MainActivityTest`. This will open an emulator (or use your device)  and run through the steps in the tests. Test statuses will be shown at the bottom of the IDE (under Run). 
+To run the tests, click on the arrows next to `class MainActivityTest`. This will open an emulator (or use your device) and run through the steps in the tests. Test statuses will be shown at the bottom of the IDE (under Run). 
 
 If you are unable to run the tests, the test cases are described in the files for you to test manually.
 


### PR DESCRIPTION
Suggest to not use beta software. Changed 
`   androidTestImplementation 'androidx.test:rules:1.4.0-beta02'    ` 
to `   androidTestImplementation 'androidx.test:rules:1.4.0'   `
Clarified instructions step to include testing module to dependency section of Gradle file.
Please check the file copy location is correct. <AndoridStuiodProjects>/<projectname>/app/src/test/java/<package sub folders>/MainActivityTest.kt